### PR TITLE
Fix incorrect binary reference in `install.sh` to use `amd64` instead of `x86_64`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,11 +9,7 @@ echo "Please note: You may be prompted for your password"
 OS=$(uname)
 ARCH=$(uname -m)
 TARGET_OS="linux"
-TARGET_ARCH="arm64"
-
-if [ "${ARCH}" == "x86_64" ]; then
-  TARGET_ARCH="x86_64"
-fi
+TARGET_ARCH="amd64"
 
 if [ "${ARCH}" == "arm64" ]; then
   TARGET_ARCH="arm64"


### PR DESCRIPTION
Since x86_64 systems return amd64 when using `uname -m`, the install.sh attempts to download an asset with x86_64 in the name, which does not exist. To resolve this, the script could default to amd64 and omit the redundant x86_64 architecture check.

Closes #20 